### PR TITLE
Update MOD files to avoid conflicting variable and function name

### DIFF
--- a/Gfluct2.mod
+++ b/Gfluct2.mod
@@ -92,7 +92,6 @@ NEURON {
 	POINT_PROCESS Gfluct2
 	RANGE g_e, g_i, E_e, E_i, g_e0, g_i0, g_e1, g_i1
 	RANGE std_e, std_i, tau_e, tau_i, D_e, D_i
-	RANGE new_seed
 	NONSPECIFIC_CURRENT i
 }
 

--- a/readme.html
+++ b/readme.html
@@ -33,4 +33,7 @@ Changelog
 ---------
 2022-05: Updated MOD files to contain valid C++ and be compatible with
          the upcoming versions 8.2 and 9.0 of NEURON.
+2022-09: Update MOD files to avoid declaring variables and functions with the same name.
+         See https://github.com/neuronsimulator/nrn/pull/1992
+
 </pre></html>


### PR DESCRIPTION
* This will be an error in the upcoming NEURON 9.0 release
* For details, see https://github.com/neuronsimulator/nrn/pull/1992
